### PR TITLE
chore: move ping import to this repo to avoid license check failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/libnetwork v0.0.0-20180914141841-20461b853933
-	github.com/erikh/ping v0.0.0-20141209185752-d731d249e12a
 	github.com/genuinetools/pkg v0.0.0-20180910213200-1c141f661797
 	github.com/godbus/dbus v4.1.0+incompatible // indirect
 	github.com/opencontainers/runc v0.0.0-20180920170208-00dc70017d22

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/libnetwork v0.0.0-20180914141841-20461b853933 h1:kYuklxtEizUcgJDn38ZYxngvGFZn4I7pdGqImZI9Bzg=
 github.com/docker/libnetwork v0.0.0-20180914141841-20461b853933/go.mod h1:93m0aTqz6z+g32wla4l4WxTrdtvBRmVzYRkYvasA5Z8=
-github.com/erikh/ping v0.0.0-20141209185752-d731d249e12a h1:xYb+yyQiRJ/j9MeLxAxY7y5zxlKJRsuJrL9aIjvm6ys=
-github.com/erikh/ping v0.0.0-20141209185752-d731d249e12a/go.mod h1:m0Cg23THf2kNTu+CtJHoq2IjqNQke24ZV8GQlGDfQf4=
 github.com/genuinetools/pkg v0.0.0-20180910213200-1c141f661797 h1:SGpZXDd/CFeDIY4Rq5cFO8K/uqDblHUxjlzOmjFpvRg=
 github.com/genuinetools/pkg v0.0.0-20180910213200-1c141f661797/go.mod h1:XTcrCYlXPxnxL2UpnwuRn7tcaTn9HAhxFoFJucootk8=
 github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=

--- a/network/allocate.go
+++ b/network/allocate.go
@@ -8,10 +8,11 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/erikh/ping"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	bolt "go.etcd.io/bbolt"
+
+	"cdr.dev/netns/network/ping"
 )
 
 // AllocateIP returns an unused IP for a specific process ID

--- a/network/create_test.go
+++ b/network/create_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"cdr.dev/netns/bridge"
-	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func TestCreateNetwork(t *testing.T) {
@@ -27,7 +27,7 @@ func TestCreateNetwork(t *testing.T) {
 	}
 	defer os.RemoveAll(defaultStateDir)
 
-	ip, err := c.Create(configs.HookState{
+	ip, err := c.Create(specs.State{
 		Pid: process.Pid,
 	}, bridge.Opt{
 		IPAddr: defaultBridgeIP,

--- a/network/ping/LICENSE
+++ b/network/ping/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/network/ping/doc.go
+++ b/network/ping/doc.go
@@ -1,0 +1,3 @@
+// Package ping contains an ICMP pinger taken originally from the Go source
+// tree. The files in this directory are licensed under ./LICENSE.
+package ping

--- a/network/ping/ping.go
+++ b/network/ping/ping.go
@@ -1,0 +1,199 @@
+// Copyright 2009 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Taken from
+// https://github.com/erikh/ping/blob/d731d249e12a103e22d5d4cdf41bf37062623ea4/ping.go
+// which was originally taken from
+// http://golang.org/src/pkg/net/ipraw_test.go
+
+package ping
+
+import (
+	"bytes"
+	"errors"
+	"net"
+	"os"
+	"time"
+)
+
+const (
+	icmpv4EchoRequest = 8
+	icmpv4EchoReply   = 0
+	icmpv6EchoRequest = 128
+	icmpv6EchoReply   = 129
+)
+
+type icmpMessage struct {
+	Type     int             // type
+	Code     int             // code
+	Checksum int             // checksum
+	Body     icmpMessageBody // body
+}
+
+type icmpMessageBody interface {
+	Len() int
+	Marshal() ([]byte, error)
+}
+
+// Marshal returns the binary enconding of the ICMP echo request or
+// reply message m.
+func (m *icmpMessage) Marshal() ([]byte, error) {
+	b := []byte{byte(m.Type), byte(m.Code), 0, 0}
+	if m.Body != nil && m.Body.Len() != 0 {
+		mb, err := m.Body.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		b = append(b, mb...)
+	}
+	switch m.Type {
+	case icmpv6EchoRequest, icmpv6EchoReply:
+		return b, nil
+	}
+	csumcv := len(b) - 1 // checksum coverage
+	s := uint32(0)
+	for i := 0; i < csumcv; i += 2 {
+		s += uint32(b[i+1])<<8 | uint32(b[i])
+	}
+	if csumcv&1 == 0 {
+		s += uint32(b[csumcv])
+	}
+	s = s>>16 + s&0xffff
+	s = s + s>>16
+	// Place checksum back in header; using ^= avoids the
+	// assumption the checksum bytes are zero.
+	b[2] ^= byte(^s & 0xff)
+	b[3] ^= byte(^s >> 8)
+	return b, nil
+}
+
+// parseICMPMessage parses b as an ICMP message.
+func parseICMPMessage(b []byte) (*icmpMessage, error) {
+	msglen := len(b)
+	if msglen < 4 {
+		return nil, errors.New("message too short")
+	}
+	m := &icmpMessage{Type: int(b[0]), Code: int(b[1]), Checksum: int(b[2])<<8 | int(b[3])}
+	if msglen > 4 {
+		var err error
+		switch m.Type {
+		case icmpv4EchoRequest, icmpv4EchoReply, icmpv6EchoRequest, icmpv6EchoReply:
+			m.Body, err = parseICMPEcho(b[4:])
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return m, nil
+}
+
+// imcpEcho represenets an ICMP echo request or reply message body.
+type icmpEcho struct {
+	ID   int    // identifier
+	Seq  int    // sequence number
+	Data []byte // data
+}
+
+func (p *icmpEcho) Len() int {
+	if p == nil {
+		return 0
+	}
+	return 4 + len(p.Data)
+}
+
+// Marshal returns the binary enconding of the ICMP echo request or
+// reply message body p.
+func (p *icmpEcho) Marshal() ([]byte, error) {
+	b := make([]byte, 4+len(p.Data))
+	b[0], b[1] = byte(p.ID>>8), byte(p.ID&0xff)
+	b[2], b[3] = byte(p.Seq>>8), byte(p.Seq&0xff)
+	copy(b[4:], p.Data)
+	return b, nil
+}
+
+// parseICMPEcho parses b as an ICMP echo request or reply message body.
+func parseICMPEcho(b []byte) (*icmpEcho, error) {
+	bodylen := len(b)
+	p := &icmpEcho{ID: int(b[0])<<8 | int(b[1]), Seq: int(b[2])<<8 | int(b[3])}
+	if bodylen > 4 {
+		p.Data = make([]byte, bodylen-4)
+		copy(p.Data, b[4:])
+	}
+	return p, nil
+}
+
+func Ping(address *net.IPAddr, timeout time.Duration) bool {
+	err := Pinger(address, timeout)
+	return err == nil
+}
+
+func Pinger(address *net.IPAddr, timeout time.Duration) error {
+	var (
+		c   *net.IPConn
+		err error
+	)
+
+	v6 := address.IP.To4() == nil
+
+	if v6 {
+		c, err = net.DialIP("ip6:ipv6-icmp", nil, address)
+	} else {
+		c, err = net.DialIP("ip4:icmp", nil, address)
+	}
+	if err != nil {
+		return err
+	}
+
+	c.SetDeadline(time.Now().Add(timeout))
+	defer c.Close()
+
+	typ := icmpv4EchoRequest
+
+	if v6 {
+		typ = icmpv6EchoRequest
+	}
+
+	xid, xseq := os.Getpid()&0xffff, 1
+	wb, err := (&icmpMessage{
+		Type: typ, Code: 0,
+		Body: &icmpEcho{
+			ID: xid, Seq: xseq,
+			Data: bytes.Repeat([]byte("Go Go Gadget Ping!!!"), 3),
+		},
+	}).Marshal()
+	if err != nil {
+		return err
+	}
+	if _, err = c.Write(wb); err != nil {
+		return err
+	}
+	var m *icmpMessage
+	rb := make([]byte, 20+len(wb))
+	for {
+		if _, err = c.Read(rb); err != nil {
+			return err
+		}
+		if !v6 {
+			rb = ipv4Payload(rb)
+		}
+		if m, err = parseICMPMessage(rb); err != nil {
+			return err
+		}
+
+		switch m.Type {
+		case icmpv4EchoRequest, icmpv6EchoRequest:
+			continue
+		}
+		break
+	}
+	return nil
+}
+
+func ipv4Payload(b []byte) []byte {
+	if len(b) < 20 {
+		return b
+	}
+	hdrlen := int(b[0]&0x0f) << 2
+	return b[hdrlen:]
+}


### PR DESCRIPTION
This package failed license checks from a customer because it doesn't have a license file, even though we were only importing (and therefore distributing) licensed code with a banner at the top of the file.

https://github.com/erikh/ping

Copied `ping.go` (licensed under Golang's license) from this repo into ours. Did not copy `ping_test.go` because it doesn't have a license.